### PR TITLE
Populate

### DIFF
--- a/backend/models/post.js
+++ b/backend/models/post.js
@@ -11,8 +11,18 @@ const postSchema = new mongoose.Schema({
     default: 0,
   },
   user: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    id: {
+      type: String,
+      required: true,
+    },
+    username: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    }
   },
   replyToPost: {
     type: mongoose.Schema.Types.ObjectId,

--- a/frontend/src/components/main/posts/Reply.js
+++ b/frontend/src/components/main/posts/Reply.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import Container from '../../assets/Container'
 import Button from '../../assets/Button'
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { getPostFromId, replyPost } from '../../../reducers/postReducer'
 
@@ -12,6 +12,7 @@ const StyledText = styled.div`
 
 const Reply = () => {
   const dispatch = useDispatch()
+  const navigate = useNavigate()
   const [isLoaded, setIsLoaded] = useState(false)
   const params = useParams()
   const { postId } = params
@@ -28,6 +29,7 @@ const Reply = () => {
     const content = e.target.replyInput.value
     e.target.replyInput.value = ''
     dispatch(replyPost(content, post.id))
+    navigate(`/main/${post.user.username}/${post.id}`)
   }
 
   return (


### PR DESCRIPTION
Removed the need for populate methods on updating of posts in the backend. This is done by modifying the postSchema, to require a declared user object attribute. There will only be one user (author) per post, so it makes sense to not require a dynamic populate method for the user attribute. 

The frontend now can reference to the user details to grab Posts and Users' states without needing an extra populate method.